### PR TITLE
String encapsulation from `string` to 'string' in collection functions

### DIFF
--- a/helper-profiles/src/main/java/me/lucko/helper/profiles/plugin/ProfilesPlugin.java
+++ b/helper-profiles/src/main/java/me/lucko/helper/profiles/plugin/ProfilesPlugin.java
@@ -29,7 +29,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-
 import me.lucko.helper.Events;
 import me.lucko.helper.Scheduler;
 import me.lucko.helper.plugin.ExtendedJavaPlugin;
@@ -39,11 +38,11 @@ import me.lucko.helper.promise.Promise;
 import me.lucko.helper.sql.DatabaseCredentials;
 import me.lucko.helper.sql.HelperDataSource;
 import me.lucko.helper.sql.SqlProvider;
-
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerLoginEvent;
 
+import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -60,8 +59,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
 
 public class ProfilesPlugin extends ExtendedJavaPlugin implements ProfileRepository {
 
@@ -335,7 +332,7 @@ public class ProfilesPlugin extends ExtendedJavaPlugin implements ProfileReposit
             if (!first) {
                 sb.append(", ");
             }
-            sb.append("UNHEX(`").append(UuidUtils.toString(uniqueId)).append("`)");
+            sb.append("UNHEX('").append(UuidUtils.toString(uniqueId)).append("')");
             first = false;
         }
 
@@ -395,7 +392,7 @@ public class ProfilesPlugin extends ExtendedJavaPlugin implements ProfileReposit
             if (!first) {
                 sb.append(", ");
             }
-            sb.append("`").append(name).append("`");
+            sb.append("'").append(name).append("'");
             first = false;
         }
 

--- a/helper-profiles/src/main/java/me/lucko/helper/profiles/plugin/ProfilesPlugin.java
+++ b/helper-profiles/src/main/java/me/lucko/helper/profiles/plugin/ProfilesPlugin.java
@@ -29,6 +29,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+
 import me.lucko.helper.Events;
 import me.lucko.helper.Scheduler;
 import me.lucko.helper.plugin.ExtendedJavaPlugin;
@@ -38,11 +39,11 @@ import me.lucko.helper.promise.Promise;
 import me.lucko.helper.sql.DatabaseCredentials;
 import me.lucko.helper.sql.HelperDataSource;
 import me.lucko.helper.sql.SqlProvider;
+
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerLoginEvent;
 
-import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -59,6 +60,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
 
 public class ProfilesPlugin extends ExtendedJavaPlugin implements ProfileRepository {
 


### PR DESCRIPTION
Simple correction of string encapsulation from `string` to 'string' in collection lookup functions that currently breaks the SQL query.