### PR TITLE
Update HelperMongo.java

### DIFF
--- a/helper-mongo/src/main/java/me/lucko/helper/mongo/plugin/HelperMongo.java
+++ b/helper-mongo/src/main/java/me/lucko/helper/mongo/plugin/HelperMongo.java
@@ -67,7 +67,6 @@ public class HelperMongo implements Mongo {
                 return LoaderUtils.getPlugin().getClassloader();
             }
         });
-        this.morphiaDatastore = this.morphia.createDatastore(this.client, credentials.getDatabase());
     }
 
     @Nonnull

--- a/helper-mongo/src/main/java/me/lucko/helper/mongo/plugin/HelperMongo.java
+++ b/helper-mongo/src/main/java/me/lucko/helper/mongo/plugin/HelperMongo.java
@@ -61,6 +61,13 @@ public class HelperMongo implements Mongo {
         this.database = this.client.getDatabase(credentials.getDatabase());
         this.morphia = new Morphia();
         this.morphiaDatastore = this.morphia.createDatastore(this.client, credentials.getDatabase());
+        this.morphia.getMapper().getOptions().setObjectFactory(new DefaultCreator() {
+            @Override
+            protected ClassLoader getClassLoaderForClass() {
+                return LoaderUtils.getPlugin().getClassloader();
+            }
+        });
+        this.morphiaDatastore = this.morphia.createDatastore(this.client, credentials.getDatabase());
     }
 
     @Nonnull


### PR DESCRIPTION
Avoids the 'Class not found defined in dbObj' & 'ClassNotFoundException' when mapping objects with bukkit. Ultimately overrides Morphia's ClassLoader with our own.