### PR TITLE
Update to 1.13.1

### DIFF
--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>helper</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.4.0</version>
 
     <name>helper</name>
     <description>A utility to reduce boilerplate code in Bukkit plugins.</description>

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>helper</artifactId>
     <packaging>jar</packaging>
-    <version>5.3.0</version>
+    <version>5.4.0-SNAPSHOT</version>
 
     <name>helper</name>
     <description>A utility to reduce boilerplate code in Bukkit plugins.</description>
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>text</artifactId>
-            <version>1.11-1.4.0</version>
+            <version>1.12-1.6.4</version>
             <scope>compile</scope>
             <optional>true</optional>
             <exclusions>

--- a/helper/src/main/java/me/lucko/helper/menu/scheme/StandardSchemeMappings.java
+++ b/helper/src/main/java/me/lucko/helper/menu/scheme/StandardSchemeMappings.java
@@ -42,10 +42,10 @@ import java.util.function.IntFunction;
 @NonnullByDefault
 public final class StandardSchemeMappings {
 
-    public static final SchemeMapping STAINED_GLASS = forColoredMaterial(Material.STAINED_GLASS_PANE);
-    public static final SchemeMapping STAINED_GLASS_BLOCK = forColoredMaterial(Material.STAINED_GLASS);
-    public static final SchemeMapping HARDENED_CLAY = forColoredMaterial(Material.STAINED_CLAY);
-    public static final SchemeMapping WOOL = forColoredMaterial(Material.WOOL);
+    public static final SchemeMapping STAINED_GLASS = forColoredMaterial(Material.GRAY_STAINED_GLASS_PANE);
+    public static final SchemeMapping STAINED_GLASS_BLOCK = forColoredMaterial(Material.GRAY_STAINED_GLASS);
+    public static final SchemeMapping HARDENED_CLAY = forColoredMaterial(Material.GRAY_TERRACOTTA);
+    public static final SchemeMapping WOOL = forColoredMaterial(Material.GRAY_WOOL);
     public static final SchemeMapping EMPTY = new EmptySchemeMapping();
 
     private static SchemeMapping forColoredMaterial(Material material) {

--- a/helper/src/main/resources/plugin.yml
+++ b/helper/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ main: me.lucko.helper.internal.StandalonePlugin
 website: https://github.com/lucko/helper
 load: STARTUP
 softdepend: [ProtocolLib, Citizens, ViaVersion]
+api-version: 1.13

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
         <skipTests>true</skipTests>
         <maven.test.skip>true</maven.test.skip>
 
-        <compiler.version>3.7.0</compiler.version>
-        <shade.version>3.1.0</shade.version>
+        <compiler.version>3.8.0</compiler.version>
+        <shade.version>3.2.0</shade.version>
         <source.version>3.0.1</source.version>
         <javadoc.version>2.10.4</javadoc.version>
 
-        <bukkit.version>1.13-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.13.1-R0.1-SNAPSHOT</bukkit.version>
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <module>helper-redis</module>
         <module>helper-mongo</module>
         <module>helper-lilypad</module>
-        <!-- <module>helper-js</module> -->
+        <module>helper-js</module>
         <module>helper-profiles</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <module>helper-redis</module>
         <module>helper-mongo</module>
         <module>helper-lilypad</module>
-        <module>helper-js</module>
+        <!-- <module>helper-js</module> -->
         <module>helper-profiles</module>
     </modules>
 
@@ -55,7 +55,7 @@
         <source.version>3.0.1</source.version>
         <javadoc.version>2.10.4</javadoc.version>
 
-        <bukkit.version>1.12.2-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.13-R0.1-SNAPSHOT</bukkit.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
The version was bumped (to 5.4.0) as compatibility for older Minecraft versions were dropped. If we remove the scheme mappings then we can keep support but it might break plugins currently using them

I personally tested this on my dev server and ran into no issues. I'm open to suggestions and changes :)