### PR TITLE
Fix null GsonSerializable

### DIFF
--- a/helper/src/main/java/me/lucko/helper/gson/typeadapters/GsonSerializableAdapterFactory.java
+++ b/helper/src/main/java/me/lucko/helper/gson/typeadapters/GsonSerializableAdapterFactory.java
@@ -58,12 +58,20 @@ public final class GsonSerializableAdapterFactory implements TypeAdapterFactory 
         TypeAdapter<? extends GsonSerializable> typeAdapter = new TypeAdapter<GsonSerializable>() {
             @Override
             public void write(JsonWriter out, GsonSerializable value) {
+                if (value == null) {
+                    gson.toJson(null, out);
+                    return;
+                }
                 gson.toJson(value.serialize(), out);
             }
 
             @Override
             public GsonSerializable read(JsonReader in) throws IOException {
                 JsonElement element = GsonProvider.parser().parse(in);
+
+                if (element.isJsonNull()) {
+                    return null;
+                }
 
                 try {
                     //noinspection unchecked


### PR DESCRIPTION
If GsonSerializable is null, GsonSerializableAdapterFactory throws NullPointerException.

You can reproduce using following code.

```java
public static void test() {
    String json = GsonProvider.standard().toJson(new SerializeTest());
    System.out.println(json);

    SerializeTest serializeTest = GsonProvider.standard().fromJson(json, SerializeTest.class);
    System.out.println(serializeTest.position);
}

public static class SerializeTest {
    public Position position = null;
}
```