### PR TITLE
HelperSql: Convenience methods, config updates.

### DIFF
--- a/helper-sql/pom.xml
+++ b/helper-sql/pom.xml
@@ -160,6 +160,13 @@
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>

--- a/helper-sql/src/main/java/me/lucko/helper/sql/BatchBuilder.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/BatchBuilder.java
@@ -1,0 +1,66 @@
+package me.lucko.helper.sql;
+
+import me.lucko.helper.Schedulers;
+import me.lucko.helper.promise.Promise;
+import me.lucko.helper.sql.util.ThrownConsumer;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a statement meant to be executed more than a single time.
+ *
+ * <p>It will be executed all at once, using a single database connection.</p>
+ */
+public interface BatchBuilder {
+
+    /**
+     * Gets the statement to be executed when this batch is finished.
+     *
+     * @return the statement to be executed
+     */
+    @Nonnull
+    String getStatement();
+
+    /**
+     * Gets a {@link Collection} of handlers for this statement.
+     *
+     * @return the handlers for this statement
+     */
+    @Nonnull
+    Collection<ThrownConsumer<PreparedStatement, SQLException>> getHandlers();
+
+    /**
+     * Resets this BatchBuilder, making it possible to re-use
+     * for multiple situations.
+     *
+     * @return this builder
+     */
+    BatchBuilder reset();
+
+    /**
+     * Adds an additional handler to be executed when this batch is finished.
+     *
+     * @param handler the statement handler
+     * @return this builder
+     */
+    BatchBuilder batch(@Nonnull ThrownConsumer<PreparedStatement, SQLException> handler);
+
+    /**
+     * Executes the statement for this batch, with the handlers used to prepare it.
+     */
+    void execute();
+
+    /**
+     * Executes the statement for this batch, with the handlers used to prepare it.
+     *
+     * <p>Will return a {@link Promise} to do this.</p>
+     *
+     * @return a promise to execute this batch asynchronously
+     */
+    @Nonnull
+    Promise<Void> executeAsync();
+}

--- a/helper-sql/src/main/java/me/lucko/helper/sql/Sql.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/Sql.java
@@ -27,10 +27,17 @@ package me.lucko.helper.sql;
 
 import com.zaxxer.hikari.HikariDataSource;
 
+import me.lucko.helper.Schedulers;
+import me.lucko.helper.promise.Promise;
+import me.lucko.helper.sql.util.ThrownConsumer;
+import me.lucko.helper.sql.util.ThrownFunction;
 import me.lucko.helper.terminable.Terminable;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
@@ -38,6 +45,8 @@ import javax.annotation.Nonnull;
  * Represents an individual SQL datasource, created by the library.
  */
 public interface Sql extends Terminable {
+
+    ThrownConsumer<PreparedStatement, SQLException> NOTHING = ThrownConsumer.nothing();
 
     /**
      * Gets the Hikari instance backing the datasource
@@ -57,4 +66,179 @@ public interface Sql extends Terminable {
     @Nonnull
     Connection getConnection() throws SQLException;
 
+    /**
+     * Executes a database statement with no preparation.
+     *
+     * <p>This will be executed on an asynchronous thread.</p>
+     *
+     * @param statement the statement to be executed
+     * @return a Promise of an asynchronous database execution
+     * @see #execute(String) to perform this action synchronously
+     */
+    @Nonnull
+    default Promise<Void> executeAsync(@Nonnull String statement) {
+        return Schedulers.async().run(() -> this.execute(statement));
+    }
+
+    /**
+     * Executes a database statement with no preparation.
+     *
+     * <p>This will be executed on whichever thread it's called from.</p>
+     *
+     * @param statement the statement to be executed
+     * @see #executeAsync(String) to perform the same action asynchronously
+     */
+    default void execute(@Nonnull String statement) {
+        this.execute(statement, NOTHING);
+    }
+
+    /**
+     * Executes a database statement with preparation.
+     *
+     * <p>This will be executed on an asynchronous thread.</p>
+     *
+     * @param statement the statement to be executed
+     * @param preparer the preparation used for this statement
+     * @return a Promise of an asynchronous database execution
+     * @see #executeAsync(String, ThrownConsumer) to perform this action synchronously
+     */
+    @Nonnull
+    default Promise<Void> executeAsync(@Nonnull String statement,
+                               @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer) {
+        return Schedulers.async().run(() -> this.execute(statement, preparer));
+    }
+
+    /**
+     * Executes a database statement with preparation.
+     *
+     * <p>This will be executed on whichever thread it's called from.</p>
+     *
+     * @param statement the statement to be executed
+     * @param preparer the preparation used for this statement
+     * @see #executeAsync(String, ThrownConsumer) to perform this action asynchronously
+     */
+    void execute(@Nonnull String statement,
+                 @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer);
+
+    /**
+     * Executes a database query with no preparation.
+     *
+     * <p>This will be executed on an asynchronous thread.</p>
+     *
+     * <p>In the case of a {@link SQLException} or in the case of
+     * no data being returned, or the handler evaluating to null,
+     * this method will return an {@link Optional#empty()} object.</p>
+     *
+     * @param query the query to be executed
+     * @param handler the handler for the data returned by the query
+     * @param <R> the returned type
+     * @return a Promise of an asynchronous database query
+     * @see #query(String, ThrownFunction) to perform this query synchronously
+     */
+    default <R> Promise<Optional<R>> queryAsync(@Nonnull String query,
+                                        @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return Schedulers.async().supply(() -> this.query(query, handler));
+    }
+
+    /**
+     * Executes a database query with no preparation.
+     *
+     * <p>This will be executed on whichever thread it's called from.</p>
+     *
+     * <p>In the case of a {@link SQLException} or in the case of
+     * no data being returned, or the handler evaluating to null,
+     * this method will return an {@link Optional#empty()} object.</p>
+     *
+     * @param query the query to be executed
+     * @param handler the handler for the data returned by the query
+     * @param <R> the returned type
+     * @return the results of the database query
+     * @see #queryAsync(String, ThrownFunction) to perform this query asynchronously
+     */
+    default <R> Optional<R> query(@Nonnull String query,
+                          @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return this.query(query, NOTHING, handler);
+    }
+
+    /**
+     * Executes a database query with preparation.
+     *
+     * <p>This will be executed on an asynchronous thread.</p>
+     *
+     * <p>In the case of a {@link SQLException} or in the case of
+     * no data being returned, or the handler evaluating to null,
+     * this method will return an {@link Optional#empty()} object.</p>
+     *
+     * @param query the query to be executed
+     * @param preparer the preparation used for this statement
+     * @param handler the handler for the data returned by the query
+     * @param <R> the returned type
+     * @return a Promise of an asynchronous database query
+     * @see #query(String, ThrownFunction) to perform this query synchronously
+     */
+    default <R> Promise<Optional<R>> queryAsync(@Nonnull String query,
+                                        @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer,
+                                        @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return Schedulers.async().supply(() -> this.query(query, preparer, handler));
+    }
+    /**
+     * Executes a database query with preparation.
+     *
+     * <p>This will be executed on whichever thread it's called from.</p>
+     *
+     * <p>In the case of a {@link SQLException} or in the case of
+     * no data being returned, or the handler evaluating to null,
+     * this method will return an {@link Optional#empty()} object.</p>
+     *
+     * @param query the query to be executed
+     * @param preparer the preparation used for this statement
+     * @param handler the handler for the data returned by the query
+     * @param <R> the returned type
+     * @return the results of the database query
+     * @see #queryAsync(String, ThrownFunction) to perform this query asynchronously
+     */
+    <R> Optional<R> query(@Nonnull String query,
+                          @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer,
+                          @Nonnull ThrownFunction<ResultSet, R, SQLException> handler);
+
+    /**
+     * Executes a batched database execution.
+     *
+     * <p>This will be executed on an asynchronous thread.</p>
+     *
+     * <p>Note that proper implementations of this method should determine
+     * if the provided {@link BatchBuilder} is actually worth of being a
+     * batched statement. For instance, a BatchBuilder with only one
+     * handler can safely be referred to {@link #executeAsync(String, ThrownConsumer)}</p>
+     *
+     * @param builder the builder to be used.
+     * @return a Promise of an asynchronous batched database execution
+     * @see #executeBatch(BatchBuilder) to perform this action synchronously
+     */
+    default Promise<Void> executeBatchAsync(@Nonnull BatchBuilder builder) {
+        return Schedulers.async().run(() -> this.executeBatch(builder));
+    }
+
+    /**
+     * Executes a batched database execution.
+     *
+     * <p>This will be executed on whichever thread it's called from.</p>
+     *
+     * <p>Note that proper implementations of this method should determine
+     * if the provided {@link BatchBuilder} is actually worth of being a
+     * batched statement. For instance, a BatchBuilder with only one
+     * handler can safely be referred to {@link #execute(String, ThrownConsumer)}</p>
+     *
+     * @param builder the builder to be used.
+     * @see #executeBatchAsync(BatchBuilder) to perform this action asynchronously
+     */
+    void executeBatch(@Nonnull BatchBuilder builder);
+
+    /**
+     * Gets a {@link BatchBuilder} for the provided statement.
+     *
+     * @param statement the statement to prepare for batching.
+     * @return a BatchBuilder
+     */
+    BatchBuilder batch(@Nonnull String statement);
 }

--- a/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSql.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSql.java
@@ -27,62 +27,179 @@ package me.lucko.helper.sql.plugin;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import me.lucko.helper.Schedulers;
+import me.lucko.helper.promise.Promise;
+import me.lucko.helper.sql.BatchBuilder;
 import me.lucko.helper.sql.DatabaseCredentials;
 import me.lucko.helper.sql.Sql;
+import me.lucko.helper.sql.util.ThrownConsumer;
+import me.lucko.helper.sql.util.ThrownFunction;
+import org.intellij.lang.annotations.Language;
 
 import javax.annotation.Nonnull;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class HelperSql implements Sql {
-    private static final AtomicInteger COUNTER = new AtomicInteger(0);
 
-    private final HikariDataSource hikari;
+    private static final AtomicInteger POOL_COUNTER = new AtomicInteger(0);
+
+    private static final Properties PROPERTIES;
+
+    private static final String DATA_SOURCE_CLASS = "org.mariadb.jdbc.MySQLDataSource";
+
+    // https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+    private static final int MAXIMUM_POOL_SIZE = (Runtime.getRuntime().availableProcessors() * 2) + 1;
+    private static final int MINIMUM_IDLE = 10;
+
+    private static final long MAX_LIFETIME = TimeUnit.MINUTES.toMillis(30); // 30 Minutes
+    private static final long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(10); // 10 seconds
+    private static final long LEAK_DETECTION_THRESHOLD = TimeUnit.SECONDS.toMillis(10); // 10 seconds
+
+    private static final String LANGUAGE = "MySQL";
+
+    static {
+        PROPERTIES = new Properties();
+
+        //http://assets.en.oreilly.com/1/event/21/Connector_J%20Performance%20Gems%20Presentation.pdf
+        PROPERTIES.setProperty("useConfigs", "maxPerformance");
+    }
+
+    private final HikariDataSource source;
 
     public HelperSql(@Nonnull DatabaseCredentials credentials) {
-        HikariConfig config = new HikariConfig();
-        config.setPoolName("helper-sql-" + COUNTER.getAndIncrement());
+        final HikariConfig hikari = new HikariConfig();
 
-        config.setDataSourceClassName("org.mariadb.jdbc.MySQLDataSource");
-        config.addDataSourceProperty("serverName", credentials.getAddress());
-        config.addDataSourceProperty("port", credentials.getPort());
-        config.addDataSourceProperty("databaseName", credentials.getDatabase());
-        config.setUsername(credentials.getUsername());
-        config.setPassword(credentials.getPassword());
+        hikari.setPoolName("helper-sql-" + POOL_COUNTER.getAndIncrement());
 
-        // pool settings
-        config.setMaximumPoolSize(25);
-        config.setMinimumIdle(10);
+        hikari.setDataSourceClassName(DATA_SOURCE_CLASS);
+        hikari.addDataSourceProperty("serverName", credentials.getAddress());
+        hikari.addDataSourceProperty("port", credentials.getPort());
+        hikari.addDataSourceProperty("databaseName", credentials.getDatabase());
 
-        // connections should not live for longer than 30 mins
-        config.setMaxLifetime(TimeUnit.MINUTES.toMillis(30));
-        // We will wait for 10 seconds to get a connection from the pool.
-        config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(10));
-        // If a connection is not returned within 10 seconds, it's probably safe to assume it's been leaked.
-        config.setLeakDetectionThreshold(TimeUnit.SECONDS.toMillis(10));
+        hikari.setUsername(credentials.getUsername());
+        hikari.setPassword(credentials.getPassword());
+
+        hikari.setDataSourceProperties(PROPERTIES);
+
+        hikari.setMaximumPoolSize(MAXIMUM_POOL_SIZE);
+        hikari.setMinimumIdle(MINIMUM_IDLE);
+
+        hikari.setMaxLifetime(MAX_LIFETIME);
+        hikari.setConnectionTimeout(CONNECTION_TIMEOUT);
+        hikari.setLeakDetectionThreshold(LEAK_DETECTION_THRESHOLD);
+
         // ensure we use unicode (this calls #setProperties, a hack for the mariadb driver)
-        config.addDataSourceProperty("properties", "useUnicode=true;characterEncoding=utf8");
+        hikari.addDataSourceProperty("properties", "useUnicode=true;characterEncoding=utf8");
 
-        this.hikari = new HikariDataSource(config);
+        this.source = new HikariDataSource(hikari);
     }
 
     @Nonnull
     @Override
     public HikariDataSource getHikari() {
-        return this.hikari;
+        return this.source;
     }
 
     @Nonnull
     @Override
     public Connection getConnection() throws SQLException {
-        return Objects.requireNonNull(this.hikari.getConnection(), "connection is null");
+        return Objects.requireNonNull(this.source.getConnection(), "connection is null");
+    }
+
+    @Nonnull
+    public Promise<Void> executeAsync(@Language(LANGUAGE) @Nonnull String statement) {
+        return Schedulers.async().run(() -> this.execute(statement));
+    }
+
+    public void execute(@Language(LANGUAGE) @Nonnull String statement) {
+        this.execute(statement, NOTHING);
+    }
+
+    @Nonnull
+    public Promise<Void> executeAsync(@Language(LANGUAGE) @Nonnull String statement,
+                                       @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer) {
+        return Schedulers.async().run(() -> this.execute(statement, preparer));
+    }
+
+    @Override
+    public void execute(@Language(LANGUAGE) @Nonnull String statement,
+                        @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer) {
+        try (Connection c = this.getConnection(); PreparedStatement s = c.prepareStatement(statement)) {
+            preparer.accept(s);
+            s.execute();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public <R> Promise<Optional<R>> queryAsync(@Language(LANGUAGE) @Nonnull String query,
+                                                @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return Schedulers.async().supply(() -> this.query(query, handler));
+    }
+
+    public <R> Optional<R> query(@Language(LANGUAGE) @Nonnull String query,
+                                  @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return this.query(query, NOTHING, handler);
+    }
+
+    public <R> Promise<Optional<R>> queryAsync(@Language(LANGUAGE) @Nonnull String query,
+                                                @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer,
+                                                @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        return Schedulers.async().supply(() -> this.query(query, preparer, handler));
+    }
+
+    @Override
+    public <R> Optional<R> query(@Language(LANGUAGE) @Nonnull String query,
+                                 @Nonnull ThrownConsumer<PreparedStatement, SQLException> preparer,
+                                 @Nonnull ThrownFunction<ResultSet, R, SQLException> handler) {
+        try (Connection c = this.getConnection(); PreparedStatement s = c.prepareStatement(query)) {
+            preparer.accept(s);
+            try (ResultSet r = s.executeQuery()) {
+                return Optional.ofNullable(handler.apply(r));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void executeBatch(@Nonnull BatchBuilder builder) {
+        if (builder.getHandlers().isEmpty()) {
+            return;
+        }
+
+        if (builder.getHandlers().size() == 1) {
+            this.execute(builder.getStatement(), builder.getHandlers().iterator().next());
+            return;
+        }
+
+        try (Connection c = this.getConnection(); PreparedStatement s = c.prepareStatement(builder.getStatement())) {
+            for (ThrownConsumer<PreparedStatement, SQLException> handlers : builder.getHandlers()) {
+                handlers.accept(s);
+                s.addBatch();
+            }
+            s.executeBatch();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public BatchBuilder batch(@Language(LANGUAGE) @Nonnull String statement) {
+        return new HelperSqlBatchBuilder(this, statement);
     }
 
     @Override
     public void close() {
-        this.hikari.close();
+        this.source.close();
     }
 }

--- a/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlBatchBuilder.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlBatchBuilder.java
@@ -1,0 +1,61 @@
+package me.lucko.helper.sql.plugin;
+
+import com.google.common.collect.Lists;
+import me.lucko.helper.promise.Promise;
+import me.lucko.helper.sql.BatchBuilder;
+import me.lucko.helper.sql.Sql;
+import me.lucko.helper.sql.util.ThrownConsumer;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.LinkedList;
+
+import javax.annotation.Nonnull;
+
+public class HelperSqlBatchBuilder implements BatchBuilder {
+
+    @Nonnull private final Sql owner;
+    @Nonnull private final String statement;
+    @Nonnull private final LinkedList<ThrownConsumer<PreparedStatement, SQLException>> handlers;
+
+    public HelperSqlBatchBuilder(@Nonnull Sql owner, @Nonnull String statement) {
+        this.owner = owner;
+        this.statement = statement;
+        this.handlers = Lists.newLinkedList();
+    }
+
+    @Nonnull
+    @Override
+    public String getStatement() {
+        return this.statement;
+    }
+
+    @Nonnull
+    @Override
+    public LinkedList<ThrownConsumer<PreparedStatement, SQLException>> getHandlers() {
+        return this.handlers;
+    }
+
+    @Override
+    public BatchBuilder reset() {
+        this.handlers.clear();
+        return this;
+    }
+
+    @Override
+    public BatchBuilder batch(@Nonnull ThrownConsumer<PreparedStatement, SQLException> handler) {
+        this.handlers.add(handler);
+        return this;
+    }
+
+    @Override
+    public void execute() {
+        this.owner.executeBatch(this);
+    }
+
+    @Nonnull
+    @Override
+    public Promise<Void> executeAsync() {
+        return this.owner.executeBatchAsync(this);
+    }
+}

--- a/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlPlugin.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlPlugin.java
@@ -50,6 +50,9 @@ public class HelperSqlPlugin extends ExtendedJavaPlugin implements SqlProvider {
         provideService(SqlProvider.class, this);
         provideService(DatabaseCredentials.class, this.globalCredentials);
         provideService(Sql.class, this.globalDataSource);
+
+        // expose specific Sql implementation
+        provideService(HelperSql.class, (HelperSql) this.globalDataSource);
     }
 
     @Nonnull

--- a/helper-sql/src/main/java/me/lucko/helper/sql/util/ThrownConsumer.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/util/ThrownConsumer.java
@@ -1,0 +1,44 @@
+package me.lucko.helper.sql.util;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A {@link java.util.function.Consumer}-copy method which is expected
+ * to throw an exception.
+ *
+ * @param <T> the type of the input to the operation
+ * @param <E> the type of error expected to be thrown
+ */
+@FunctionalInterface
+public interface ThrownConsumer<T, E extends Throwable> {
+
+    /**
+     * @see java.util.function.Consumer#accept(Object)
+     *
+     * @throws E when the exception is thrown
+     */
+    void accept(T t) throws E;
+
+    /**
+     * @see java.util.function.Consumer#andThen(Consumer)
+     */
+    default ThrownConsumer<T, E> andThen(ThrownConsumer<? super T, E> after) {
+        Objects.requireNonNull(after);
+        return t -> {
+            this.accept(t);
+            after.accept(t);
+        };
+    }
+
+    /**
+     * Gets a ThrownConsumer which does absolutely nothing.
+     *
+     * @param <T> the type of the input to the operation
+     * @param <E> the type of error expected to be thrown
+     * @return a ThrownConsumer which does absolutely nothing
+     */
+    static <T, E extends Throwable> ThrownConsumer<T, E> nothing() {
+        return t -> { };
+    }
+}

--- a/helper-sql/src/main/java/me/lucko/helper/sql/util/ThrownFunction.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/util/ThrownFunction.java
@@ -1,0 +1,50 @@
+package me.lucko.helper.sql.util;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ *  * A {@link java.util.function.Function}-copy method which is expected
+ *  * to throw an exception.
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ * @param <E> the type of error expected to be thrown
+ */
+@FunctionalInterface
+public interface ThrownFunction<T, R, E extends Throwable> {
+
+    /**
+     * @see java.util.function.Function#apply(Object)
+     *
+     * @throws E when the exception is thrown
+     */
+    R apply(T t) throws E;
+
+    /**
+     * @see java.util.function.Function#compose(Function)
+     */
+    default <V> ThrownFunction<V, R, E> compose(ThrownFunction<? super V, ? extends T, E> before) {
+        Objects.requireNonNull(before);
+        return v -> this.apply(before.apply(v));
+    }
+
+    /**
+     * @see java.util.function.Function#andThen(Function)
+     */
+    default <V> ThrownFunction<T, V, E> andThen(ThrownFunction<? super R, ? extends V, E> after) {
+        Objects.requireNonNull(after);
+        return t -> after.apply(this.apply(t));
+    }
+
+    /**
+     * Gets a ThrownFunction which returns the input argument.
+     * 
+     * @param <R> the type of both the input argument and the result of the function
+     * @param <E> the type of error expected to be thrown
+     * @return a ThrownFunction which returns the input argument
+     */
+    static <R, E extends Throwable> ThrownFunction<R, R, E> nothing() {
+        return r -> r;
+    }
+}


### PR DESCRIPTION
Adds a number of convenience methods and a couple of configuration updates.

# Configuration Updates

Namely, the settings in the implementation provided by `HelperSql` have been made into Constants for ease of viewing and access for downstream consumers/forks to make modifications or understand the default configurations.

In addition, two configurations have been added entirely:

**useConfigs=maxPerformance**:

Connector/J has a setting which implies a number of configuration modifications behind `maxPerformance`. It's a little unclear whether or not they're applied to `mariadb-java-client`, but the addition can't hurt. You can view more information about this setting [from this article](http://assets.en.oreilly.com/1/event/21/Connector_J%20Performance%20Gems%20Presentation.pdf).

**maximumPoolSize**:

I believe this was set to 25, however [based on this article](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) I've changed it to be dynamically allotted to `processors * 2 + 1`.

# Convenience Methods

I've added a number of convenience methods which make interfacing with the `Connection` a million times easier.

**Examples**:
```java
        sql.execute("INSERT INTO workers (first_name, last_name, wages) VALUES (?, ?, ?)", s -> { 
            s.setString(1, "Ferus");
            s.setString(2, "Grim");
            s.setBigDecimal(3, new BigDecimal(Double.MAX_VALUE)); 
        });
        
        BigDecimal wages = sql.query("SELECT wages FROM workers WHERE first_name=? AND last_name=?", s -> { 
            s.setString(1, "Ferus");
            s.setString(2, "Grim"); 
            }, r -> { 
            if (r.next()) { 
                return r.getBigDecimal("wages"); 
            }
            return null; 
        }).orElse(BigDecimal.ZERO);
```

Additionally, there are asynchronous alternatives of those methods which return an unbound `Promise<Void>`, such as `executeAsync`.

## BatchBuilder

Another convenience feature is a batch builder, which allows for extremely easy creation of batched database executions.

**Examples**:

```java

        final Iterator<Worker> workers = workers.iterator();
        BatchBuilder batch = sql.batch("INSERT INTO workers (first_name, last_name, wages) VALUES (?, ?, ?)");
        
        while (workers.hasNext()) {
            final Worker worker = workers.next();
            batch.batch(s -> {
                s.setString(1, worker.getFirstName());
                s.setString(2, worker.getLastName());
                s.setBigDecimal(3, worker.getWages());
            });
        }
        
        batch.execute();
```