### PR TITLE
Invalidate Guis on PlayerDeathEvent

### DIFF
--- a/helper/src/main/java/me/lucko/helper/menu/Gui.java
+++ b/helper/src/main/java/me/lucko/helper/menu/Gui.java
@@ -39,6 +39,7 @@ import me.lucko.helper.utils.annotation.NonnullByDefault;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -299,6 +300,12 @@ public abstract class Gui implements TerminableConsumer {
      * Registers the event handlers for this GUI
      */
     private void startListening() {
+        Events.subscribe(PlayerDeathEvent.class)
+                .filter(e -> e.getEntity().equals(this.player))
+                .filter(e -> isValid())
+                .handler(e -> invalidate())
+                .bindWith(this);
+        
         Events.subscribe(InventoryClickEvent.class)
                 .filter(e -> e.getInventory().getHolder() != null)
                 .filter(e -> e.getInventory().getHolder().equals(this.player))

--- a/helper/src/main/java/me/lucko/helper/menu/Gui.java
+++ b/helper/src/main/java/me/lucko/helper/menu/Gui.java
@@ -44,7 +44,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerEvent;
-import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.Inventory;


### PR DESCRIPTION
You would think that InventoryCloseEvent would be sufficient, however a moderator on our server discovered it's possible to dupe items by exploiting a glitch in which helper believes a previous menu is still active.

https://www.youtube.com/watch?v=rKJPrAelml8

The fix for this is just to invalidate the menu on PlayerDeathEvent, as well.

EDIT: There was another dupe glitch discovered which was rectified in the same manner: Invaliding the GUI on PlayerChangedWorldEvent and PlayerTeleportEvent.

PlayerTeleportEvent turned out to be the catalyst, however I've left PlayerChangedWorldEvent as it didn't seem to cause any additional issues, and I'd rather not take it out in the off-chance an enterprising player discovered another way to mess with it.

Here's the video for the update: https://www.youtube.com/watch?v=kTbG6O8PHh8