### PR TITLE
Fix ability to drag (and lose) items in menus

### DIFF
--- a/helper/src/main/java/me/lucko/helper/menu/Gui.java
+++ b/helper/src/main/java/me/lucko/helper/menu/Gui.java
@@ -42,6 +42,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -312,6 +313,16 @@ public abstract class Gui implements TerminableConsumer {
                 .filter(p -> isValid())
                 .handler(p -> invalidate())
                 .bindWith(this);
+
+        Events.subscribe(InventoryDragEvent.class)
+                .filter(e -> e.getInventory().getHolder() != null)
+                .filter(e -> e.getInventory().getHolder().equals(this.player))
+                .handler(e -> {
+                    e.setCancelled(true);
+                    if (!isValid()) {
+                        close();
+                    }
+                }).bindWith(this);
 
         Events.subscribe(InventoryClickEvent.class)
                 .filter(e -> e.getInventory().getHolder() != null)


### PR DESCRIPTION
Prefacing, this doesn't break the menu and doesn't allow for duping. However, it's possible to lose items permanently.

I've had a video made to show how to duplicate this bug, but I have confirmed that this PR will fix it.

https://youtu.be/9sZJhH6cvW8

To explain the bug:

1. Put yourself into a situation where your inventory can be closed automatically with some kind of delay.
    - In the video, this is done via being pushed by water.
2. Put an ItemStack on your cursor.
3. Wait for your inventory to be closed automatically.
    - Despite the inventory having been closed, the ItemStack still exists on your cursor.
4. Open a menu without opening your player inventory
    - In the video, this is done via right-clicking a Gui-opening robot.
5. Drag the items around in the inventory.

The problem is that InventoryClickEvent was the only consideration to be cancelled under the (fair) assumption that any other events would be impossible to be reached.

This PR simply cancels any drag events.