### PR TITLE
Add utils to optionally set placeholders only if PAPI is installed

### DIFF
--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -324,6 +324,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- placeholderapi -->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.10.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/helper/src/main/java/me/lucko/helper/text/Text.java
+++ b/helper/src/main/java/me/lucko/helper/text/Text.java
@@ -25,12 +25,16 @@
 
 package me.lucko.helper.text;
 
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import net.kyori.text.adapter.bukkit.TextAdapter;
 import net.kyori.text.serializer.ComponentSerializers;
 
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -41,6 +45,7 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("deprecation")
 public final class Text {
+    private static final Plugin PAPIPLUGIN = Bukkit.getPluginManager().getPlugin("PlaceholderAPI");
 
     public static final char SECTION_CHAR = '\u00A7'; // §
     public static final char AMPERSAND_CHAR = '&';
@@ -94,6 +99,78 @@ public final class Text {
             }
         }
         return new String(b);
+    }
+
+    /**
+     * Sets PlaceholderAPI placeholders to a text,
+     * or just colorizes it if PlaceholderAPI is not installed.
+     *
+     * @param text the text on which to set placeholders
+     * @return the text with placeholders replaced,
+     * or just the text colorized if PlaceholderAPI is not installed (and will not be thrown a {@link ClassNotFoundException})
+     */
+    public static String setPlaceholders(String text) {
+        return setPlaceholders(null, text);
+    }
+
+    /**
+     * Sets PlaceholderAPI placeholders to a text,
+     * taking information from the supplied sender if it is an {@link OfflinePlayer},
+     * or just colorizes it if PlaceholderAPI is not installed.
+     *
+     * @param sender the sender from which to take information if it is an {@link OfflinePlayer}
+     * @param text the text on which to set placeholders
+     * @return the text with the placeholders replaced, with sender's information if it's an {@link OfflinePlayer},
+     * or just the text colorized if PlaceholderAPI is not installed (and will not be thrown a {@link ClassNotFoundException})
+     */
+    public static String setPlaceholders(CommandSender sender, String text) {
+        if (isPlaceholderAPISupported()) {
+            if (sender instanceof OfflinePlayer) {
+                return PlaceholderAPI.setPlaceholders((OfflinePlayer) sender, text);
+            }
+
+            return PlaceholderAPI.setPlaceholders(null, text);
+        }
+
+        return colorize(text);
+    }
+
+    /**
+     * Sets PlaceholderAPI bracket placeholders to a text,
+     * or just colorizes it if PlaceholderAPI is not installed.
+     *
+     * @param text the text on which to set placeholders
+     * @return the text with bracket placeholders replaced,
+     * or just the text colorized if PlaceholderAPI is not installed (and will not be thrown a {@link ClassNotFoundException})
+     */
+    public static String setBracketPlaceholders(String text) {
+        return setBracketPlaceholders(null, text);
+    }
+
+    /**
+     * Sets PlaceholderAPI bracket placeholders to a text,
+     * taking information from the supplied sender if it is an {@link OfflinePlayer},
+     * or just colorizes it if PlaceholderAPI is not installed.
+     *
+     * @param sender the sender from which to take information if it is an {@link OfflinePlayer}
+     * @param text the text on which to set placeholders
+     * @return the text with the bracket placeholders replaced, with sender's information if it's an {@link OfflinePlayer},
+     * or just the text colorized if PlaceholderAPI is not installed (and will not be thrown a {@link ClassNotFoundException})
+     */
+    public static String setBracketPlaceholders(CommandSender sender, String text) {
+        if (isPlaceholderAPISupported()) {
+            if (sender instanceof OfflinePlayer) {
+                return PlaceholderAPI.setBracketPlaceholders((OfflinePlayer) sender, text);
+            }
+
+            return PlaceholderAPI.setBracketPlaceholders(null, text);
+        }
+
+        return colorize(text);
+    }
+
+    private static boolean isPlaceholderAPISupported() {
+        return PAPIPLUGIN != null && PAPIPLUGIN.isEnabled();
     }
 
     private Text() {


### PR DESCRIPTION
These utils will set placeholders if PlaceholderAPI is installed, otherwise they will only colorize the text, without throwing a ClassNotFoundException.