### PR TITLE
1.8-specific floating inventory fix.

### DIFF
--- a/helper/src/main/java/me/lucko/helper/menu/Gui.java
+++ b/helper/src/main/java/me/lucko/helper/menu/Gui.java
@@ -332,6 +332,11 @@ public abstract class Gui implements TerminableConsumer {
 
                     if (!isValid()) {
                         close();
+                        return;
+                    }
+
+                    if (!e.getInventory().equals(this.inventory)) {
+                        return;
                     }
 
                     int slotId = e.getRawSlot();


### PR DESCRIPTION
It's possible to get your inventory into a floating state where multiple virtual "inventories" are active.

This doesn't directly solve that issue, but ensures that no actions are run if the clicked inventory is not the Helper GUI.