### PR TITLE
Replace http urls with https

### DIFF
--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -80,7 +80,7 @@ public final class LibraryLoader {
     }
 
     public static void load(String groupId, String artifactId, String version) {
-        load(groupId, artifactId, version, "http://repo1.maven.org/maven2");
+        load(groupId, artifactId, version, "https://repo1.maven.org/maven2");
     }
 
     public static void load(String groupId, String artifactId, String version, String repoUrl) {

--- a/helper/src/main/java/me/lucko/helper/maven/MavenLibrary.java
+++ b/helper/src/main/java/me/lucko/helper/maven/MavenLibrary.java
@@ -73,6 +73,6 @@ public @interface MavenLibrary {
      * @return the repo where the library can be obtained from
      */
     @Nonnull
-    Repository repo() default @Repository(url = "http://repo1.maven.org/maven2");
+    Repository repo() default @Repository(url = "https://repo1.maven.org/maven2");
 
 }


### PR DESCRIPTION
As of January 15th this year, maven central does no longer support http urls. Therefore downloading artifacts via http will fail.

Read more about it here: https://support.sonatype.com/hc/en-us/articles/360041287334