### PR TITLE
Fix Gui getting slots after invalidation

### DIFF
--- a/helper/src/main/java/me/lucko/helper/menu/DummySlot.java
+++ b/helper/src/main/java/me/lucko/helper/menu/DummySlot.java
@@ -1,3 +1,28 @@
+/*
+ * This file is part of helper, licensed under the MIT License.
+ *
+ *  Copyright (c) lucko (Luck) <luck@lucko.me>
+ *  Copyright (c) contributors
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
 package me.lucko.helper.menu;
 
 import org.bukkit.event.inventory.ClickType;

--- a/helper/src/main/java/me/lucko/helper/menu/DummySlot.java
+++ b/helper/src/main/java/me/lucko/helper/menu/DummySlot.java
@@ -1,0 +1,119 @@
+package me.lucko.helper.menu;
+
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Useless implementation of {@link Slot} to fulfill not-null contracts.
+ */
+public class DummySlot implements Slot {
+
+    // the parent gui
+    private final Gui gui;
+
+    // the id of this slot
+    private final int id;
+
+    public DummySlot(@Nonnull Gui gui, int id) {
+        this.gui = gui;
+        this.id = id;
+    }
+
+    @Nonnull
+    @Override
+    public Gui gui() {
+        return this.gui;
+    }
+
+    @Override
+    public int getId() {
+        return this.id;
+    }
+
+    @Override
+    public Slot applyFromItem(Item item) {
+        return this;
+    }
+
+    @Nullable
+    @Override
+    public ItemStack getItem() {
+        return null;
+    }
+
+    @Override
+    public boolean hasItem() {
+        return false;
+    }
+
+    @Nonnull
+    @Override
+    public Slot setItem(@Nonnull ItemStack item) {
+        return this;
+    }
+
+    @Override
+    public Slot clear() {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot clearItem() {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot clearBindings() {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot clearBindings(ClickType type) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot bind(@Nonnull ClickType type, @Nonnull Consumer<InventoryClickEvent> handler) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot bind(@Nonnull ClickType type, @Nonnull Runnable handler) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot bind(@Nonnull Consumer<InventoryClickEvent> handler, @Nonnull ClickType... types) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public Slot bind(@Nonnull Runnable handler, @Nonnull ClickType... types) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Runnable> Slot bindAllRunnables(@Nonnull Iterable<Map.Entry<ClickType, T>> handlers) {
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public <T extends Consumer<InventoryClickEvent>> Slot bindAllConsumers(@Nonnull Iterable<Map.Entry<ClickType, T>> handlers) {
+        return this;
+    }
+}


### PR DESCRIPTION
This glitch was reported to me today, and this fix was implemented. However, I feel as though there is likely a better way to implement this fix so I am very open to criticisms and suggestions.

It seems as though there are some instances where a Gui can have items applied to it, even after that Gui has been invalidated. Because the Gui has been invalidated, it isn't listening and, thus, items can be pulled from the inventory.

In [this video](https://youtu.be/OsTdpfDSaX0), you can see this in action. The piston pushing the player seems to call for Gui invalidation. Because the menu is loading player heads, it's done on a scheduler and then placed in the Gui. Even though the Scheduler is bound to the Gui, the method which places them into it are still called.

The Gui attempts to close, but this weird state that the piston forces on the player won't allow it. This fix, even, cannot close the Gui, but rather ensures additional items cannot be placed.

I chose to create a new boolean `invalidated`, to lessen the impact on existing systems. This is, technically, a change which possibly alters expected behaviors of implementations, though I can't imagine many scenarios in which you'd purposefully want to add items to an invalidated Gui.

Using `isValid` is obviously not possible because it's expected to be set to `true` after the first call to `redraw`, which cannot happen if `getSlot` is throwing exceptions.

Please, any requests for alterations and better ideas is much appreciated.