### PR TITLE
Fix clashing HologramLines

### DIFF
--- a/helper/src/main/java/me/lucko/helper/hologram/individual/PacketIndividualHologramFactory.java
+++ b/helper/src/main/java/me/lucko/helper/hologram/individual/PacketIndividualHologramFactory.java
@@ -429,7 +429,9 @@ public class PacketIndividualHologramFactory implements IndividualHologramFactor
 
             Protocol.subscribe(ListenerPriority.HIGH, PacketType.Play.Server.ENTITY_METADATA)
                     .handler(e -> {
-                        PacketContainer packet = e.getPacket();
+                        PacketContainer packet = e.getPacket().deepClone();
+                        e.setPacket(packet);
+                        
                         Player player = e.getPlayer();
 
                         // get entity id


### PR DESCRIPTION
Certain packets, such as Entity Equipment, Entity Metadata or Update Tile Entity, share the same instance when they are sent by the server. For such packets, metadata in this case, only the last written change will be preserved. Thus, the packet receiver will only see what the last written change was.

The solution is to clone the packet before modification.