### PR TITLE
Check for description null instead of permission.

### DIFF
--- a/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilderImpl.java
+++ b/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilderImpl.java
@@ -60,7 +60,7 @@ class FunctionalCommandBuilderImpl<T extends CommandSender> implements Functiona
     }
 
     public FunctionalCommandBuilder<T> description(String description) {
-        Objects.requireNonNull(permission, "description");
+        Objects.requireNonNull(description, "description");
         this.description = description;
         return this;
     }


### PR DESCRIPTION
This just fixes an issue where it checks for the `permission` field to not be null instead of the actual `description` parameter. Basically if you didn't set up a permission before setting a description, it throws!