### PR TITLE
Expose Hologram ArmorStands

### DIFF
--- a/helper/src/main/java/me/lucko/helper/hologram/BaseHologram.java
+++ b/helper/src/main/java/me/lucko/helper/hologram/BaseHologram.java
@@ -28,8 +28,10 @@ package me.lucko.helper.hologram;
 import me.lucko.helper.serialize.Position;
 import me.lucko.helper.terminable.Terminable;
 
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 
+import java.util.Collection;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
@@ -56,6 +58,23 @@ public interface BaseHologram extends Terminable {
      * @return true if spawned and active, or false otherwise
      */
     boolean isSpawned();
+
+    /**
+     * Gets the ArmorStands that hold the lines for this hologram
+     *
+     * @return the ArmorStands holding the lines
+     */
+    @Nonnull
+    Collection<ArmorStand> getArmorStands();
+
+    /**
+     * Gets the ArmorStand holding the specified line
+     *
+     * @param line the line
+     * @return the ArmorStand holding this line
+     */
+    @Nullable
+    ArmorStand getArmorStand(int line);
 
     /**
      * Updates the position of the hologram and respawns it

--- a/helper/src/main/java/me/lucko/helper/hologram/BukkitHologramFactory.java
+++ b/helper/src/main/java/me/lucko/helper/hologram/BukkitHologramFactory.java
@@ -48,6 +48,7 @@ import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -207,6 +208,21 @@ public class BukkitHologramFactory implements HologramFactory {
             return true;
         }
 
+        @Nonnull
+        @Override
+        public Collection<ArmorStand> getArmorStands() {
+            return spawnedEntities;
+        }
+
+        @Nullable
+        @Override
+        public ArmorStand getArmorStand(int line) {
+            if (line >= spawnedEntities.size()) {
+                return null;
+            }
+            return spawnedEntities.get(line);
+        }
+
         @Override
         public void updatePosition(@Nonnull Position position) {
             Objects.requireNonNull(position, "position");
@@ -236,6 +252,7 @@ public class BukkitHologramFactory implements HologramFactory {
             this.lines.addAll(ret);
         }
 
+        @Override
         public void setClickCallback(@Nullable Consumer<Player> clickCallback) {
             // unregister any existing listeners
             if (clickCallback == null) {

--- a/helper/src/main/java/me/lucko/helper/hologram/individual/PacketIndividualHologramFactory.java
+++ b/helper/src/main/java/me/lucko/helper/hologram/individual/PacketIndividualHologramFactory.java
@@ -52,6 +52,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,6 +62,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -273,6 +275,21 @@ public class PacketIndividualHologramFactory implements IndividualHologramFactor
             }
 
             return true;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<ArmorStand> getArmorStands() {
+            return spawnedEntities.stream().map(HologramEntity::getArmorStand).collect(Collectors.toSet());
+        }
+
+        @Nullable
+        @Override
+        public ArmorStand getArmorStand(int line) {
+            if (line >= spawnedEntities.size()) {
+                return null;
+            }
+            return spawnedEntities.get(line).armorStand;
         }
 
         @Override


### PR DESCRIPTION
Currently, setClickCallback doesn't work (at least for BukkitHologramFactory.BukkitHologram).

I'm going to be making a PR soon which will fix this, but for now, this is part of my hotfix, as I needed something quicker than I could implement the fix.

### Before
```java
    private static final Field SPAWNED_ENTITIES_FIELD;
    static {
        Field spawnedEntitiesField = null;
        try {
            Class<?> clazz = Class.forName("me.lucko.helper.hologram.BukkitHologramFactory$BukkitHologram");
            spawnedEntitiesField = clazz.getDeclaredField("spawnedEntities");
            spawnedEntitiesField.setAccessible(true);
        } catch (Throwable e) {
            e.printStackTrace();
        }
        SPAWNED_ENTITIES_FIELD = spawnedEntitiesField;
    }

    private List<UUID> getHologramEntityIds(Hologram hologram) {
        try {
            return ((List<ArmorStand>) SPAWNED_ENTITIES_FIELD.get(hologram)).stream()
                    .map(Entity::getUniqueId)
                    .collect(Collectors.toList());
        } catch (IllegalAccessException e) {
            e.printStackTrace();
            return Lists.newArrayList();
        }
    }
```

### After
```java
    private List<UUID> getHologramEntityIds(Hologram hologram) {
        return hologram.getArmorStands().stream()
                .map(Entity::getUniqueId)
                .collect(Collectors.toList());
    }
```