### PR TITLE
Fix clickable holograms for BukkitHologramFactory

### DIFF
--- a/helper/src/main/java/me/lucko/helper/hologram/BukkitHologramFactory.java
+++ b/helper/src/main/java/me/lucko/helper/hologram/BukkitHologramFactory.java
@@ -29,21 +29,27 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
 
 import me.lucko.helper.Events;
+import me.lucko.helper.Helper;
 import me.lucko.helper.gson.JsonBuilder;
 import me.lucko.helper.reflect.MinecraftVersion;
 import me.lucko.helper.reflect.MinecraftVersions;
 import me.lucko.helper.serialize.Position;
 import me.lucko.helper.terminable.composite.CompositeTerminable;
-import me.lucko.helper.text.Text;
 
+import me.lucko.helper.text3.Text;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.entity.PigZapEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -83,6 +89,7 @@ public class BukkitHologramFactory implements HologramFactory {
 
         private CompositeTerminable listeners = null;
         private Consumer<Player> clickCallback = null;
+        private final List<Pig> spawnedPassengers = new ArrayList<>();
 
         BukkitHologram(Position position, List<String> lines) {
             this.position = Objects.requireNonNull(position, "position");
@@ -113,6 +120,11 @@ public class BukkitHologramFactory implements HologramFactory {
                     // get and remove the last entry
                     ArmorStand as = this.spawnedEntities.remove(this.spawnedEntities.size() - 1);
                     as.remove();
+
+                    if (this.listeners != null) {
+                        Pig pig = this.spawnedPassengers.remove(this.spawnedPassengers.size() - 1);
+                        pig.remove();
+                    }
                 }
             }
 
@@ -159,6 +171,26 @@ public class BukkitHologramFactory implements HologramFactory {
                         } catch (IllegalAccessException | InvocationTargetException e) {
                             e.printStackTrace();
                         }
+                    }
+
+                    if (this.listeners != null) {
+                        Pig pig = (Pig) as.getWorld().spawnEntity(as.getLocation(), EntityType.PIG);
+                        pig.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false));
+                        pig.setCustomNameVisible(false);
+                        pig.setSilent(true);
+                        pig.setGravity(false);
+
+                        pig.setMetadata("nodespawn", new FixedMetadataValue(Helper.hostPlugin(), true));
+
+                        if (MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersions.v1_9)) {
+                            pig.setAI(false);
+                            pig.setCollidable(false);
+                            pig.setInvulnerable(true);
+                        }
+
+                        as.addPassenger(pig);
+
+                        this.spawnedPassengers.add(pig);
                     }
 
                     this.spawnedEntities.add(as);
@@ -211,16 +243,16 @@ public class BukkitHologramFactory implements HologramFactory {
         @Nonnull
         @Override
         public Collection<ArmorStand> getArmorStands() {
-            return spawnedEntities;
+            return this.spawnedEntities;
         }
 
         @Nullable
         @Override
         public ArmorStand getArmorStand(int line) {
-            if (line >= spawnedEntities.size()) {
+            if (line >= this.spawnedEntities.size()) {
                 return null;
             }
-            return spawnedEntities.get(line);
+            return this.spawnedEntities.get(line);
         }
 
         @Override
@@ -268,14 +300,51 @@ public class BukkitHologramFactory implements HologramFactory {
 
             if (this.listeners == null) {
                 this.listeners = CompositeTerminable.create();
-                Events.subscribe(PlayerInteractAtEntityEvent.class)
-                        .filter(e -> e.getRightClicked() instanceof ArmorStand)
+
+                this.listeners.bind(() -> {
+                    this.spawnedPassengers.forEach(Entity::remove);
+                    this.spawnedPassengers.clear();
+                });
+
+                this.spawnedPassengers.forEach(Entity::remove);
+                this.spawnedPassengers.clear();
+
+                for (ArmorStand as : this.spawnedEntities) {
+                    Pig pig = (Pig) as.getWorld().spawnEntity(as.getLocation(), EntityType.PIG);
+                    pig.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false));
+                    pig.setCustomNameVisible(false);
+                    pig.setSilent(true);
+                    pig.setGravity(false);
+
+                    pig.setMetadata("nodespawn", new FixedMetadataValue(Helper.hostPlugin(), true));
+
+                    if (MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersions.v1_9)) {
+                        pig.setAI(false);
+                        pig.setCollidable(false);
+                        pig.setInvulnerable(true);
+                    }
+
+                    as.addPassenger(pig);
+                }
+
+                Events.subscribe(PigZapEvent.class)
+                        .handler(e -> {
+                            for (Pig spawned : this.spawnedPassengers) {
+                                if (spawned.equals(e.getEntity())) {
+                                    e.setCancelled(true);
+                                    return;
+                                }
+                            }
+                        }).bindWith(this.listeners);
+
+                Events.subscribe(PlayerInteractEntityEvent.class)
+                        .filter(e -> e.getRightClicked() instanceof Pig)
                         .handler(e -> {
                             Player p = e.getPlayer();
-                            ArmorStand as = (ArmorStand) e.getRightClicked();
+                            Pig pig = (Pig) e.getRightClicked();
 
-                            for (ArmorStand spawned : this.spawnedEntities) {
-                                if (spawned.equals(as)) {
+                            for (Pig spawned : this.spawnedPassengers) {
+                                if (spawned.equals(pig)) {
                                     e.setCancelled(true);
                                     this.clickCallback.accept(p);
                                     return;
@@ -285,14 +354,14 @@ public class BukkitHologramFactory implements HologramFactory {
                         .bindWith(this.listeners);
 
                 Events.subscribe(EntityDamageByEntityEvent.class)
-                        .filter(e -> e.getEntity() instanceof ArmorStand)
+                        .filter(e -> e.getEntity() instanceof Pig)
                         .filter(e -> e.getDamager() instanceof Player)
                         .handler(e -> {
                             Player p = (Player) e.getDamager();
-                            ArmorStand as = (ArmorStand) e.getEntity();
+                            Pig pig = (Pig) e.getEntity();
 
-                            for (ArmorStand spawned : this.spawnedEntities) {
-                                if (spawned.equals(as)) {
+                            for (Pig spawned : this.spawnedPassengers) {
+                                if (spawned.equals(pig)) {
                                     e.setCancelled(true);
                                     this.clickCallback.accept(p);
                                     return;


### PR DESCRIPTION
Holograms which use `HologramFactory` (which, by default, delegates to the `BukkitHologramFactory`), stopped working at some point. The issue seems to be that Bukkit/Spigot no longer fires the requisite events on invisible ArmorStand objects.

My fix for this is simple: When a Hologram is clickable, spawn Pigs as passenger for the ArmorStands, and listen to those, instead.

From all the testing I've done, I also believe that `IndividualHologramFactory` is no longer working, as well. However, given this relies on packets and packet listening, rather than events, I'm honestly not entirely certain why this would be and am much more hesitant to work on a fix for it. Additionally, given I don't use it, I have very little motivation, for which I apologize.

If anyone wants to tackle that, please feel free.