### PR TITLE
Remove server from map on shutdown

### DIFF
--- a/helper/src/main/java/me/lucko/helper/network/AbstractNetwork.java
+++ b/helper/src/main/java/me/lucko/helper/network/AbstractNetwork.java
@@ -93,6 +93,7 @@ public class AbstractNetwork implements Network {
                 case "disconnect":
                     if (!instanceData.getId().equals(message.id)) {
                         postEvent(new ServerDisconnectEvent(message.id, message.reason));
+                        servers.remove(message.id);
                     }
                     break;
             }


### PR DESCRIPTION
No apparent reason to keep servers in memory after they're shutdown.