### PR TITLE
Fix VectorPoint returning incorrect Location for supplied World parameter

### DIFF
--- a/helper/src/main/java/me/lucko/helper/serialize/VectorPoint.java
+++ b/helper/src/main/java/me/lucko/helper/serialize/VectorPoint.java
@@ -87,7 +87,7 @@ public final class VectorPoint implements GsonSerializable {
     }
 
     public synchronized Location toLocation(World world) {
-        if (this.bukkitLocation == null) {
+        if (this.bukkitLocation == null || !this.bukkitLocation.getWorld().equals(world)) {
             this.bukkitLocation = new Location(world, this.position.getX(), this.position.getY(), this.position.getZ(), this.direction.getYaw(), this.direction.getPitch());
         }
 


### PR DESCRIPTION
`VectorPoint` has a `toLocation(World)` method which, when called, will cache and return a `Location` object. However, subsequent calls of `toLocation(World)` will always return the `Location` object cached in the first call, regardless of whether or not the supplied `World` has changed.

There were a number of possible solutions to this:

1. Don't cache the `Location` object at all.
2. Create a `Map<String, Location>` cache which uses the `World#getName()` value to lookup cached results.
3. Re-cache the `Location` object if the supplied `World` is different.

I opted for option 3 because it would have the least impact on performance with the least code changes.