### PR TITLE
Use sun.misc.Unsafe to inject URLs into ClassLoaders on Java 9+

### DIFF
--- a/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlPlugin.java
+++ b/helper-sql/src/main/java/me/lucko/helper/sql/plugin/HelperSqlPlugin.java
@@ -26,6 +26,7 @@
 package me.lucko.helper.sql.plugin;
 
 import me.lucko.helper.internal.HelperImplementationPlugin;
+import me.lucko.helper.maven.MavenLibrary;
 import me.lucko.helper.plugin.ExtendedJavaPlugin;
 import me.lucko.helper.sql.DatabaseCredentials;
 import me.lucko.helper.sql.Sql;
@@ -34,7 +35,7 @@ import me.lucko.helper.sql.SqlProvider;
 import javax.annotation.Nonnull;
 
 @HelperImplementationPlugin
-//@MavenLibrary(groupId = "org.slf4j", artifactId = "slf4j-api", version = "1.7.30")
+@MavenLibrary(groupId = "org.slf4j", artifactId = "slf4j-api", version = "1.7.30")
 public class HelperSqlPlugin extends ExtendedJavaPlugin implements SqlProvider {
     private DatabaseCredentials globalCredentials;
     private Sql globalDataSource;

--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -54,7 +54,7 @@ public final class LibraryLoader {
             Method addUrlMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
             addUrlMethod.setAccessible(true);
             return addUrlMethod::invoke;
-        } catch (NoSuchMethodException e) {
+        } catch (ReflectiveOperationException e) {
             return UnsafeInserter.create((URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader());
         }
     });

--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -44,11 +44,8 @@ import java.util.Objects;
 /**
  * Resolves {@link MavenLibrary} annotations for a class, and loads the dependency
  * into the classloader.
- *
- * @deprecated No longer works on Java 16+, no plans to fix.
  */
 @NonnullByDefault
-@Deprecated
 public final class LibraryLoader {
 
     @SuppressWarnings("Guava")

--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -52,13 +52,13 @@ import java.util.Objects;
 public final class LibraryLoader {
 
     @SuppressWarnings("Guava")
-    private static final Supplier<Method> ADD_URL_METHOD = Suppliers.memoize(() -> {
+    private static final Supplier<URLInjector> ADD_URL = Suppliers.memoize(() -> {
         try {
             Method addUrlMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
             addUrlMethod.setAccessible(true);
-            return addUrlMethod;
+            return addUrlMethod::invoke;
         } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
+            return UnsafeInserter.create((URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader());
         }
     });
 
@@ -123,7 +123,7 @@ public final class LibraryLoader {
 
         URLClassLoader classLoader = (URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader();
         try {
-            ADD_URL_METHOD.get().invoke(classLoader, saveLocation.toURI().toURL());
+            ADD_URL.get().addURL(classLoader, saveLocation.toURI().toURL());
         } catch (Exception e) {
             throw new RuntimeException("Unable to load dependency: " + saveLocation.toString(), e);
         }

--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -55,7 +55,7 @@ public final class LibraryLoader {
             addUrlMethod.setAccessible(true);
             return addUrlMethod::invoke;
         } catch (ReflectiveOperationException e) {
-            return UnsafeInserter.create((URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader());
+            return UnsafeURLInjector.create((URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader());
         }
     });
 

--- a/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
+++ b/helper/src/main/java/me/lucko/helper/maven/LibraryLoader.java
@@ -49,7 +49,7 @@ import java.util.Objects;
 public final class LibraryLoader {
 
     @SuppressWarnings("Guava")
-    private static final Supplier<URLInjector> ADD_URL = Suppliers.memoize(() -> {
+    private static final Supplier<URLInjector> URL_INJECTOR = Suppliers.memoize(() -> {
         try {
             Method addUrlMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
             addUrlMethod.setAccessible(true);
@@ -120,7 +120,7 @@ public final class LibraryLoader {
 
         URLClassLoader classLoader = (URLClassLoader) LoaderUtils.getPlugin().getClass().getClassLoader();
         try {
-            ADD_URL.get().addURL(classLoader, saveLocation.toURI().toURL());
+            URL_INJECTOR.get().addURL(classLoader, saveLocation.toURI().toURL());
         } catch (Exception e) {
             throw new RuntimeException("Unable to load dependency: " + saveLocation.toString(), e);
         }

--- a/helper/src/main/java/me/lucko/helper/maven/MavenLibraries.java
+++ b/helper/src/main/java/me/lucko/helper/maven/MavenLibraries.java
@@ -39,7 +39,6 @@ import javax.annotation.Nonnull;
 @Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface MavenLibraries {
 
     @Nonnull

--- a/helper/src/main/java/me/lucko/helper/maven/MavenLibrary.java
+++ b/helper/src/main/java/me/lucko/helper/maven/MavenLibrary.java
@@ -36,14 +36,11 @@ import javax.annotation.Nonnull;
 
 /**
  * Annotation to indicate a required library for a class.
- *
- * @deprecated No longer works on Java 16+, no plans to fix.
  */
 @Documented
 @Repeatable(MavenLibraries.class)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface MavenLibrary {
 
     /**

--- a/helper/src/main/java/me/lucko/helper/maven/Repository.java
+++ b/helper/src/main/java/me/lucko/helper/maven/Repository.java
@@ -39,7 +39,6 @@ import javax.annotation.Nonnull;
 @Documented
 @Target(ElementType.LOCAL_VARIABLE)
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface Repository {
 
     /**

--- a/helper/src/main/java/me/lucko/helper/maven/URLInjector.java
+++ b/helper/src/main/java/me/lucko/helper/maven/URLInjector.java
@@ -1,0 +1,21 @@
+package me.lucko.helper.maven;
+
+import javax.annotation.Nonnull;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Handles injecting URLs into a {@link URLClassLoader}
+ */
+interface URLInjector {
+
+    /**
+     * Adds the given URL to the class loader
+     *
+     * @param classLoader ClassLoader to add to
+     * @param url         URL to add
+     * @throws Exception Any exception whilst adding
+     */
+    void addURL(@Nonnull ClassLoader classLoader, @Nonnull URL url) throws Exception;
+
+}

--- a/helper/src/main/java/me/lucko/helper/maven/UnsafeInserter.java
+++ b/helper/src/main/java/me/lucko/helper/maven/UnsafeInserter.java
@@ -1,0 +1,56 @@
+package me.lucko.helper.maven;
+
+import sun.misc.Unsafe;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+
+/**
+ * An implementation of {@link URLInjector} that uses sun.misc.Unsafe to
+ * inject URLs directly into a {@link URLClassLoader}'s paths.
+ * <p>
+ * This implementation works on Java 9+ only.
+ */
+final class UnsafeInserter implements URLInjector {
+
+    private final ArrayDeque<URL> unopenedURLs;
+    private final ArrayList<URL> pathURLs;
+
+    public UnsafeInserter(final ArrayDeque<URL> unopenedURLs, final ArrayList<URL> pathURLs) {
+        this.unopenedURLs = unopenedURLs;
+        this.pathURLs = pathURLs;
+    }
+
+    public static URLInjector create(final URLClassLoader classLoader) {
+        try {
+            final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            final Unsafe unsafe = (Unsafe) field.get(null);
+            final Object ucp = fetchField(unsafe, URLClassLoader.class, classLoader, "ucp");
+            final ArrayDeque<URL> unopenedURLs = (ArrayDeque<URL>) fetchField(unsafe, ucp, "unopenedUrls");
+            final ArrayList<URL> pathURLs = (ArrayList<URL>) fetchField(unsafe, ucp, "path");
+            return new UnsafeInserter(unopenedURLs, pathURLs);
+        } catch (Throwable t) {
+            return (loader, url) -> { throw new UnsupportedOperationException(); };
+        }
+    }
+
+    private static Object fetchField(final Unsafe unsafe, final Object object, final String name) throws NoSuchFieldException {
+        return fetchField(unsafe, object.getClass(), object, name);
+    }
+
+    private static Object fetchField(final Unsafe unsafe, final Class<?> clazz, final Object object, final String name) throws NoSuchFieldException {
+        final Field field = clazz.getDeclaredField(name);
+        final long offset = unsafe.objectFieldOffset(field);
+        return unsafe.getObject(object, offset);
+    }
+
+    @Override public void addURL(@Nonnull ClassLoader classLoader, @Nonnull URL url) {
+        unopenedURLs.addLast(url);
+        pathURLs.add(url);
+    }
+}

--- a/helper/src/main/java/me/lucko/helper/maven/UnsafeURLInjector.java
+++ b/helper/src/main/java/me/lucko/helper/maven/UnsafeURLInjector.java
@@ -15,12 +15,12 @@ import java.util.ArrayList;
  * <p>
  * This implementation works on Java 9+ only.
  */
-final class UnsafeInserter implements URLInjector {
+final class UnsafeURLInjector implements URLInjector {
 
     private final ArrayDeque<URL> unopenedURLs;
     private final ArrayList<URL> pathURLs;
 
-    public UnsafeInserter(final ArrayDeque<URL> unopenedURLs, final ArrayList<URL> pathURLs) {
+    public UnsafeURLInjector(final ArrayDeque<URL> unopenedURLs, final ArrayList<URL> pathURLs) {
         this.unopenedURLs = unopenedURLs;
         this.pathURLs = pathURLs;
     }
@@ -33,7 +33,7 @@ final class UnsafeInserter implements URLInjector {
             final Object ucp = fetchField(unsafe, URLClassLoader.class, classLoader, "ucp");
             final ArrayDeque<URL> unopenedURLs = (ArrayDeque<URL>) fetchField(unsafe, ucp, "unopenedUrls");
             final ArrayList<URL> pathURLs = (ArrayList<URL>) fetchField(unsafe, ucp, "path");
-            return new UnsafeInserter(unopenedURLs, pathURLs);
+            return new UnsafeURLInjector(unopenedURLs, pathURLs);
         } catch (Throwable t) {
             return (loader, url) -> { throw new UnsupportedOperationException(); };
         }


### PR DESCRIPTION
Since the Maven library features in helper are deemed broken on Java 16+, this PR adapts and utilizes [SlimJar's UnsafeInjectable](https://github.com/slimjar/slimjar/blob/master/slimjar/src/main/java/io/github/slimjar/injector/loader/UnsafeInjectable.java) to inject URLs into URLClassLoaders using sun.misc.Unsafe. This solution works well on Java 9+ and can be used to get the API to work again.

**Side implementation note**: UnsafeURLInjector _only_ works on Java 9+. [While it is possible to make it work for Java 8 by replacing ArrayDeque with a generic Collection, and use `urls` as the field name for Java 8](https://github.com/lucko/helper/commit/e9efc940d84b5fb41cc9ffe4310e4fe7b839674f#diff-0519ea5ff66bca2a00d92b1b85fd8e019c40732df9fe0715fffcbfe30fcb38ddR34), I believe this is unnecessary since you can directly use reflections to add URLs on that version.