### PR TITLE
Fix helper-redis race condition

### DIFF
--- a/helper-redis/pom.xml
+++ b/helper-redis/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>helper-redis</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 
     <name>helper-redis</name>
     <description>Provides Redis clients and implements the helper Messaging system using Jedis.</description>
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.10.1</version>
+            <version>3.6.0</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/helper-redis/src/main/java/me/lucko/helper/redis/plugin/HelperRedisPlugin.java
+++ b/helper-redis/src/main/java/me/lucko/helper/redis/plugin/HelperRedisPlugin.java
@@ -32,8 +32,6 @@ import me.lucko.helper.redis.Redis;
 import me.lucko.helper.redis.RedisCredentials;
 import me.lucko.helper.redis.RedisProvider;
 
-import java.util.concurrent.CompletableFuture;
-
 import javax.annotation.Nonnull;
 
 @HelperImplementationPlugin
@@ -63,7 +61,7 @@ public class HelperRedisPlugin extends ExtendedJavaPlugin implements RedisProvid
     @Nonnull
     @Override
     public Redis getRedis(@Nonnull RedisCredentials credentials) {
-        return CompletableFuture.supplyAsync(() -> new HelperRedis(credentials)).join();
+        return new HelperRedis(credentials);
     }
 
     @Nonnull


### PR DESCRIPTION
helper-redis has a race condition where channels are subscribed to each on their own thread, while the underlying Jedis instance is not thread safe. This is problematic as the confirmations of each subscription can interfere with each other, preventing it being read correctly. While helper-redis is able to recover most of the time, sometimes it can prevent some or all channels from functioning.

This PR adds a ReentrantLock to each instance of `subscribe` and `unsubscribe`, which prevents this from happening.

I have also updated the jedis version, bumped the package version, and removed some redundant code.