### PR TITLE
Fix PacketScoreboard for 1.17

### DIFF
--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -158,6 +158,13 @@
         </profile>
     </profiles>
 
+    <repositories>
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- shadow -->
         <dependency>
@@ -314,7 +321,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.5.0</version>
+            <version>4.7.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- citizens -->

--- a/helper/src/main/java/me/lucko/helper/scoreboard/PacketScoreboardTeam.java
+++ b/helper/src/main/java/me/lucko/helper/scoreboard/PacketScoreboardTeam.java
@@ -425,8 +425,7 @@ public class PacketScoreboardTeam implements ScoreboardTeam {
                 // set suffix - String(16)
                 packet.getStrings().write(3, getSuffix());
             }
-        }
-        if(!GTEQ_1_17) {
+            
             // set friendly flags - byte - Bit mask. 0x01: Allow friendly fire, 0x02: can see invisible entities on same team
             int data = 0;
             if (isAllowFriendlyFire()) {

--- a/helper/src/main/java/me/lucko/helper/scoreboard/PacketScoreboardTeam.java
+++ b/helper/src/main/java/me/lucko/helper/scoreboard/PacketScoreboardTeam.java
@@ -55,7 +55,7 @@ public class PacketScoreboardTeam implements ScoreboardTeam {
     private static final boolean SUPPORTS_COLLISION_RULE = MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersions.v1_9);
     // anything >= 1.13 uses chat components for display name, prefix and suffix
     private static final boolean GTEQ_1_13 = MinecraftVersion.getRuntimeVersion().isAfterOrEq(MinecraftVersions.v1_13);
-    // I think 1.17 uses strings again or something
+    // 1.17 uses fancy optional subpacket structure so has to be handled in a specific way
     private static final boolean GTEQ_1_17 = PackageVersion.runtimeVersion().isAfterOrEq(PackageVersion.v1_17_R1);
 
     // the display name value in teams if limited to 32 chars
@@ -375,7 +375,7 @@ public class PacketScoreboardTeam implements ScoreboardTeam {
         // set mode - byte
         packet.getIntegers().write(GTEQ_1_13 ? 0 : 1, UpdateType.UPDATE.getCode());
         if(GTEQ_1_17){
-            InternalStructure subPacket = (InternalStructure) packet.getOptionalStructures().readSafely(0).get();
+            InternalStructure subPacket = packet.getOptionalStructures().readSafely(0).get();
             // set display name - Component
             subPacket.getChatComponents().write(0, PacketScoreboard.toComponent(getDisplayName()));
 


### PR DESCRIPTION
1.17 introduced some changes to the protocol. This code addresses the changes and fixes PacketScoreboard on 1.17 and (hopefully) later.