### PR TITLE
Fix paginated GUI and sign prompt

### DIFF
--- a/helper-js/pom.xml
+++ b/helper-js/pom.xml
@@ -140,12 +140,6 @@
             <version>[5.0.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/helper-lilypad/pom.xml
+++ b/helper-lilypad/pom.xml
@@ -95,12 +95,6 @@
             <version>[5.5.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- helper-lilypad related dependencies -->
         <dependency>

--- a/helper-mongo/pom.xml
+++ b/helper-mongo/pom.xml
@@ -136,12 +136,6 @@
             <version>[5.0.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- helper-mongo related dependencies -->
         <dependency>

--- a/helper-profiles/pom.xml
+++ b/helper-profiles/pom.xml
@@ -127,12 +127,6 @@
             <version>[5.0.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- helper-profiles related dependencies -->
         <dependency>

--- a/helper-redis/pom.xml
+++ b/helper-redis/pom.xml
@@ -132,12 +132,6 @@
             <version>[5.0.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- helper-redis related dependencies -->
         <dependency>

--- a/helper-sql/pom.xml
+++ b/helper-sql/pom.xml
@@ -137,12 +137,6 @@
             <version>[5.0.0,6.0.0)</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- helper-sql related dependencies -->
         <dependency>

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -311,12 +311,6 @@
             <version>3.0.2</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>${bukkit.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- protocollib -->
         <dependency>
             <groupId>com.comphenix.protocol</groupId>

--- a/helper/src/main/java/me/lucko/helper/menu/scheme/StandardSchemeMappings.java
+++ b/helper/src/main/java/me/lucko/helper/menu/scheme/StandardSchemeMappings.java
@@ -30,6 +30,8 @@ import me.lucko.helper.item.ItemStackBuilder;
 import me.lucko.helper.utils.annotation.NonnullByDefault;
 import org.bukkit.Material;
 
+import java.util.Arrays;
+
 /**
  * Contains a number of default {@link SchemeMapping}s.
  */
@@ -37,16 +39,33 @@ import org.bukkit.Material;
 public final class StandardSchemeMappings {
 
     private static final Range<Integer> COLORED_MATERIAL_RANGE = Range.closed(0, 15);
+    private static final String[] BLOCk_COLORS = {
+            "WHITE", "ORANGE", "MAGENTA", "LIGHT_BLUE", "YELLOW", "LIME", "PINK", "GRAY",
+            "LIGHT_GRAY", "CYAN", "PURPLE", "BLUE", "BROWN", "GREEN", "RED", "BLACK",
+    };
 
-    public static final SchemeMapping STAINED_GLASS = forColoredMaterial(Material.STAINED_GLASS_PANE);
-    public static final SchemeMapping STAINED_GLASS_BLOCK = forColoredMaterial(Material.STAINED_GLASS);
-    public static final SchemeMapping HARDENED_CLAY = forColoredMaterial(Material.STAINED_CLAY);
-    public static final SchemeMapping WOOL = forColoredMaterial(Material.WOOL);
+    public static final SchemeMapping STAINED_GLASS = forColoredMaterial("STAINED_GLASS_PANE", "_STAINED_GLASS_PANE");
+    public static final SchemeMapping STAINED_GLASS_BLOCK = forColoredMaterial("STAINED_GLASS", "_STAINED_GLASS");
+    public static final SchemeMapping HARDENED_CLAY = forColoredMaterial("STAINED_CLAY", "_TERRACOTTA");
+    public static final SchemeMapping WOOL = forColoredMaterial("WOOL", "_WOOL");
     public static final SchemeMapping EMPTY = new EmptySchemeMapping();
 
-    private static SchemeMapping forColoredMaterial(Material material) {
+    private static SchemeMapping forColoredMaterial(String legacyName, String modernSuffix) {
+        Material material = Material.getMaterial(legacyName);
+
+        if (material != null) {
+            return FunctionalSchemeMapping.of(
+                    data -> ItemStackBuilder.of(material).name("&f").data(data).build(null),
+                    COLORED_MATERIAL_RANGE
+            );
+        }
+
+        Material[] materials = Arrays.stream(BLOCk_COLORS)
+                .map(color -> Material.valueOf(color + modernSuffix))
+                .toArray(Material[]::new);
+
         return FunctionalSchemeMapping.of(
-                data -> ItemStackBuilder.of(material).name("&f").data(data).build(null),
+                data -> ItemStackBuilder.of(materials[data]).name("&f").build(null),
                 COLORED_MATERIAL_RANGE
         );
     }
@@ -54,5 +73,4 @@ public final class StandardSchemeMappings {
     private StandardSchemeMappings() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }
-
 }

--- a/helper/src/main/resources/plugin.yml
+++ b/helper/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ main: me.lucko.helper.internal.StandalonePlugin
 website: https://github.com/lucko/helper
 load: STARTUP
 softdepend: [ProtocolLib, Citizens, ViaVersion]
+api-version: 1.13

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
             <version>${bukkit.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,15 @@
         </profile>
     </profiles>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
+            <version>${bukkit.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <repositories>
         <repository>
             <id>luck-repo</id>
@@ -123,7 +132,7 @@
         </repository>
         <repository>
             <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This pull request includes two small fixes (I can split in two PRs if you prefer):
* Fix paginated GUI on 1.13+ servers (closes #84)
* Fix sign prompt on 1.8 servers (closes #93)

I also included the `api-version: 1.13` in the `plugin.yml` to prevent warnings and the unnecessary remapping on 1.13 servers when helper is used as a standalone plugin, but everything still works on legacy servers, and same on modern servers when helper is shaded in a plugin without an `api-version` in the `plugin.yml`.
