### PR TITLE
Rework DurationFormatter to allow for more abstract implementations

### DIFF
--- a/helper/src/main/java/me/lucko/helper/time/DurationFormatter.java
+++ b/helper/src/main/java/me/lucko/helper/time/DurationFormatter.java
@@ -117,7 +117,7 @@ public enum DurationFormatter {
         Unit(ChronoUnit unit) {
             this.duration = unit.getDuration().getSeconds();
             this.formalStringPlural = " " + unit.name().toLowerCase();
-            this.formalStringSingular = unit.name().substring(0, unit.name().length() - 1).toLowerCase();
+            this.formalStringSingular = " " + unit.name().substring(0, unit.name().length() - 1).toLowerCase();
             this.conciseString = String.valueOf(Character.toLowerCase(unit.name().charAt(0)));
         }
 


### PR DESCRIPTION
I debated deprecating the existing enumeration support, but I don't think it's necessary as they still serve a convenience purpose and help improve code clarity most the time.

I did run the following highly professional _unit_ tests to confirm functionality:

```
System.out.println("CTest 1: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), true, 1));
System.out.println("CTest 2: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), true, 2));
System.out.println("CTest 3: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), true, 3));
System.out.println("CTest 4: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), true, 4));
System.out.println("CTest 5: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), true));
System.out.println("CTest 6: " + DurationFormatter.format(Duration.of(-1, ChronoUnit.SECONDS), true));

System.out.println("LTest 1: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), false, 1));
System.out.println("LTest 2: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), false, 2));
System.out.println("LTest 3: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), false, 3));
System.out.println("LTest 4: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), false, 4));
System.out.println("LTest 5: " + DurationFormatter.format(Duration.of(1337420, ChronoUnit.SECONDS), false));
System.out.println("LTest 6: " + DurationFormatter.format(Duration.of(-1, ChronoUnit.SECONDS), false));

System.out.println("OTest 1: " + DurationFormatter.CONCISE.format(Duration.of(1337420, ChronoUnit.SECONDS)));
System.out.println("OTest 2: " + DurationFormatter.CONCISE_LOW_ACCURACY.format(Duration.of(1337420, ChronoUnit.SECONDS)));
System.out.println("OTest 3: " + DurationFormatter.LONG.format(Duration.of(1337420, ChronoUnit.SECONDS)));
```

Which functioned as expected:

```
[16:20:07 INFO]: CTest 1: 2w
[16:20:07 INFO]: CTest 2: 2w 1d
[16:20:07 INFO]: CTest 3: 2w 1d 11h
[16:20:07 INFO]: CTest 4: 2w 1d 11h 30m
[16:20:07 INFO]: CTest 5: 2w 1d 11h 30m 20s
[16:20:07 INFO]: CTest 6: 0s

[16:20:07 INFO]: LTest 1: 2 weeks
[16:20:07 INFO]: LTest 2: 2 weeks 1day
[16:20:07 INFO]: LTest 3: 2 weeks 1day 11 hours
[16:20:07 INFO]: LTest 4: 2 weeks 1day 11 hours 30 minutes
[16:20:07 INFO]: LTest 5: 2 weeks 1day 11 hours 30 minutes 20 seconds
[16:20:07 INFO]: LTest 6: 0 seconds

[16:20:07 INFO]: OTest 1: 2w 1d 11h 30m 20s
[16:20:07 INFO]: OTest 2: 2w 1d 11h
[16:20:07 INFO]: OTest 3: 2 weeks 1day 11 hours 30 minutes 20 seconds
```