### PR TITLE
Fix redis race condition bug, modify exception logging to throw events

### DIFF
--- a/helper/src/main/java/me/lucko/helper/Schedulers.java
+++ b/helper/src/main/java/me/lucko/helper/Schedulers.java
@@ -25,6 +25,15 @@
 
 package me.lucko.helper;
 
+import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import me.lucko.helper.exception.HelperException;
+import me.lucko.helper.exception.HelperExceptionEvent;
 import me.lucko.helper.interfaces.Delegate;
 import me.lucko.helper.internal.LoaderUtils;
 import me.lucko.helper.promise.ThreadContext;
@@ -35,18 +44,8 @@ import me.lucko.helper.scheduler.Ticks;
 import me.lucko.helper.scheduler.builder.TaskBuilder;
 import me.lucko.helper.utils.Log;
 import me.lucko.helper.utils.annotation.NonnullByDefault;
-
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
-
-import java.util.Objects;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
-import javax.annotation.Nonnull;
 
 /**
  * Provides common instances of {@link Scheduler}.
@@ -189,7 +188,9 @@ public final class Schedulers {
                 this.backingTask.accept(this);
                 this.counter.incrementAndGet();
             } catch (Throwable e) {
-                Log.severe("[SCHEDULER] Exception thrown whilst executing task");
+                String msg = "Exception thrown whilst executing Bukkit task";
+                Log.severe("[SCHEDULER] " + msg);
+                Events.call(new HelperExceptionEvent(new HelperException(msg, e)));
                 e.printStackTrace();
             }
 
@@ -246,8 +247,10 @@ public final class Schedulers {
                 this.backingTask.accept(this);
                 this.counter.incrementAndGet();
             } catch (Throwable e) {
-                Log.severe("[SCHEDULER] Exception thrown whilst executing task");
+                String msg = "Exception thrown whilst executing async task";
+                Log.severe("[SCHEDULER] " + msg);
                 e.printStackTrace();
+                Events.call(new HelperExceptionEvent(new HelperException(msg, e)));
             }
         }
 

--- a/helper/src/main/java/me/lucko/helper/event/functional/single/HelperEventListener.java
+++ b/helper/src/main/java/me/lucko/helper/event/functional/single/HelperEventListener.java
@@ -25,9 +25,12 @@
 
 package me.lucko.helper.event.functional.single;
 
+import me.lucko.helper.Events;
 import me.lucko.helper.Helper;
 import me.lucko.helper.event.SingleSubscription;
 
+import me.lucko.helper.exception.HelperException;
+import me.lucko.helper.exception.HelperExceptionEvent;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
@@ -139,6 +142,10 @@ class HelperEventListener<T extends Event> implements SingleSubscription<T>, Eve
             // increment call counter
             this.callCount.incrementAndGet();
         } catch (Throwable t) {
+            if (!(event instanceof HelperExceptionEvent)) {
+                String msg = "Exception thrown when handling " + event.getEventName();
+                Events.call(new HelperExceptionEvent(new HelperException(msg, t)));
+            }
             this.exceptionConsumer.accept(eventInstance, t);
         }
 

--- a/helper/src/main/java/me/lucko/helper/exception/HelperException.java
+++ b/helper/src/main/java/me/lucko/helper/exception/HelperException.java
@@ -1,0 +1,19 @@
+package me.lucko.helper.exception;
+
+public class HelperException extends Exception {
+    public HelperException(String message) {
+        super(message);
+    }
+
+    public HelperException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HelperException(Throwable cause) {
+        super(cause);
+    }
+
+    protected HelperException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/helper/src/main/java/me/lucko/helper/exception/HelperExceptionEvent.java
+++ b/helper/src/main/java/me/lucko/helper/exception/HelperExceptionEvent.java
@@ -1,0 +1,28 @@
+package me.lucko.helper.exception;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class HelperExceptionEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private HelperException exception;
+
+    public HelperExceptionEvent(HelperException exception) {
+        super(!Bukkit.isPrimaryThread());
+        this.exception = Preconditions.checkNotNull(exception, "exception");
+    }
+
+    public HelperException getException() {
+        return this.exception;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/helper/src/main/java/me/lucko/helper/reflect/NmsVersion.java
+++ b/helper/src/main/java/me/lucko/helper/reflect/NmsVersion.java
@@ -113,6 +113,14 @@ public enum NmsVersion {
     v1_16_R3(
             MinecraftVersion.of(1, 16, 4),
             MinecraftVersion.of(1, 16, 5)
+    ),
+    v1_17_R1(
+            MinecraftVersion.of(1, 17, 0),
+            MinecraftVersion.of(1, 17, 1)
+    ),
+    v1_18_R1(
+            MinecraftVersion.of(1, 18, 0),
+            MinecraftVersion.of(1, 18, 1)
     );
 
     private final Set<MinecraftVersion> minecraftVersions;


### PR DESCRIPTION
Redis bug fix is originally by @okx-code, fixes an issue where a race condition could corrupt the state of the listener.

The other addition is calling an event when an exception occurs with information about the exception for usage in deployments tracking exceptions for reliability purposes.

For some reason, the 1.17.1 and 1.18.1 NMS version stuff is in this PR too but that's already merged. Thx GitHub