### PR TITLE
1.18.2

### DIFF
--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>me.lucko</groupId>
             <artifactId>shadow-bukkit</artifactId>
-            <version>1.18.1</version>
+            <version>1.18.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- flowpowered math -->
@@ -315,7 +315,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- citizens -->

--- a/helper/src/main/java/me/lucko/helper/reflect/MinecraftVersion.java
+++ b/helper/src/main/java/me/lucko/helper/reflect/MinecraftVersion.java
@@ -51,12 +51,12 @@ public final class MinecraftVersion implements Comparable<MinecraftVersion> {
     /**
      * The newest known version of Minecraft
      */
-    private static final String NEWEST_MINECRAFT_VERSION = "1.18.1";
+    private static final String NEWEST_MINECRAFT_VERSION = "1.18.2";
 
     /**
      * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version was released.
      */
-    private static final String MINECRAFT_LAST_RELEASE_DATE = "2021-12-10";
+    private static final String MINECRAFT_LAST_RELEASE_DATE = "2022-02-28";
 
     /**
      * Gets the {@link MinecraftVersion} of the runtime server.

--- a/helper/src/main/java/me/lucko/helper/reflect/NmsVersion.java
+++ b/helper/src/main/java/me/lucko/helper/reflect/NmsVersion.java
@@ -120,7 +120,8 @@ public enum NmsVersion {
     ),
     v1_18_R1(
             MinecraftVersion.of(1, 18, 0),
-            MinecraftVersion.of(1, 18, 1)
+            MinecraftVersion.of(1, 18, 1),
+            MinecraftVersion.of(1, 18, 2)
     );
 
     private final Set<MinecraftVersion> minecraftVersions;

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
         <skipTests>true</skipTests>
         <maven.test.skip>true</maven.test.skip>
 
-        <compiler.version>3.8.1</compiler.version>
+        <compiler.version>3.10.1</compiler.version>
         <shade.version>3.2.4</shade.version>
-        <source.version>3.0.1</source.version>
-        <javadoc.version>3.2.0</javadoc.version>
+        <source.version>3.2.1</source.version>
+        <javadoc.version>3.3.2</javadoc.version>
 
         <bukkit.version>1.12.2-R0.1-SNAPSHOT</bukkit.version>
     </properties>
@@ -87,7 +87,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Updates shadow-bukkit to 1.18.2, adds 1.18.2 to nmsversions and updates maven plugins to their latest version.

It compiles but not tested yet (although it should work)