### PR TITLE
Clean up some redundant login in Expiring cache

### DIFF
--- a/helper/src/main/java/me/lucko/helper/cache/Expiring.java
+++ b/helper/src/main/java/me/lucko/helper/cache/Expiring.java
@@ -54,8 +54,7 @@ public final class Expiring<T> implements Supplier<T> {
 
     private volatile T value;
 
-    // when to expire. 0 means "not yet initialized".
-    private volatile long expirationNanos;
+    private volatile long expirationNanos = System.nanoTime();
 
     private Expiring(Supplier<T> supplier, long duration, TimeUnit unit) {
         this.supplier = supplier;
@@ -67,7 +66,7 @@ public final class Expiring<T> implements Supplier<T> {
         long nanos = this.expirationNanos;
         long now = System.nanoTime();
 
-        if (nanos == 0 || now - nanos >= 0) {
+        if (now - nanos >= 0) {
             synchronized (this) {
                 if (nanos == this.expirationNanos) { // recheck for lost race
                     // compute the value using the delegate
@@ -76,9 +75,8 @@ public final class Expiring<T> implements Supplier<T> {
 
                     // reset expiration timer
                     nanos = now + this.durationNanos;
-                    // In the very unlikely event that nanos is 0, set it to 1;
-                    // no one will notice 1 ns of tardiness.
-                    this.expirationNanos = (nanos == 0) ? 1 : nanos;
+
+                    this.expirationNanos = nanos;
                     return t;
                 }
             }


### PR DESCRIPTION
I noticed that the whole check for `nanos == 0` can be avoided if `this.expirationNanos` is initialized as System.nanoTime().

Please correct me if I'm wrong.