### PR TITLE
Add optional aliases and register method within command builder.

### DIFF
--- a/helper/src/main/java/me/lucko/helper/command/AbstractCommand.java
+++ b/helper/src/main/java/me/lucko/helper/command/AbstractCommand.java
@@ -37,6 +37,7 @@ import org.bukkit.command.TabCompleter;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An abstract implementation of {@link Command} and {@link CommandExecutor}
@@ -47,10 +48,17 @@ public abstract class AbstractCommand implements Command, CommandExecutor, TabCo
     protected @Nullable String permission;
     protected @Nullable String permissionMessage;
     protected @Nullable String description;
+    protected @Nullable String[] aliases;
 
     @Override
     public void register(String... aliases) {
         LoaderUtils.getPlugin().registerCommand(this, permission, permissionMessage, description, aliases);
+    }
+
+    @Override
+    public void register() {
+        Objects.requireNonNull(this.aliases, "aliases");
+        register(this.aliases);
     }
 
     @Override

--- a/helper/src/main/java/me/lucko/helper/command/Command.java
+++ b/helper/src/main/java/me/lucko/helper/command/Command.java
@@ -38,6 +38,11 @@ import java.util.List;
 public interface Command extends Terminable {
 
     /**
+     * Registers this command with the server, via the given plugin instance.
+     */
+    void register();
+
+    /**
      * Registers this command with the server, via the given plugin instance
      *
      * @param aliases the aliases for the command

--- a/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommand.java
+++ b/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommand.java
@@ -44,13 +44,14 @@ class FunctionalCommand extends AbstractCommand {
     private final FunctionalCommandHandler handler;
     private @Nullable final FunctionalTabHandler tabHandler;
 
-    FunctionalCommand(ImmutableList<Predicate<CommandContext<?>>> predicates, FunctionalCommandHandler handler, @Nullable FunctionalTabHandler tabHandler, @Nullable String permission, @Nullable String permissionMessage, @Nullable String description) {
+    FunctionalCommand(ImmutableList<Predicate<CommandContext<?>>> predicates, FunctionalCommandHandler handler, @Nullable FunctionalTabHandler tabHandler, @Nullable String permission, @Nullable String permissionMessage, @Nullable String description, @Nullable String... aliases) {
         this.predicates = predicates;
         this.handler = handler;
         this.tabHandler = tabHandler;
         this.permission = permission;
         this.permissionMessage = permissionMessage;
         this.description = description;
+        this.aliases = aliases;
     }
 
     @Override

--- a/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilder.java
+++ b/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilder.java
@@ -57,6 +57,8 @@ public interface FunctionalCommandBuilder<T extends CommandSender> {
         return new FunctionalCommandBuilderImpl<>();
     }
 
+    FunctionalCommandBuilder<T> aliases(String... aliases);
+
     /**
      * Sets the command description to the specified one.
      *

--- a/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilderImpl.java
+++ b/helper/src/main/java/me/lucko/helper/command/functional/FunctionalCommandBuilderImpl.java
@@ -49,17 +49,26 @@ class FunctionalCommandBuilderImpl<T extends CommandSender> implements Functiona
     private @Nullable String permission;
     private @Nullable String permissionMessage;
     private @Nullable String description;
+    private @Nullable String[] aliases;
 
-    private FunctionalCommandBuilderImpl(ImmutableList.Builder<Predicate<CommandContext<?>>> predicates, @Nullable FunctionalTabHandler tabHandler, @Nullable String permission, @Nullable String permissionMessage, @Nullable String description) {
+    private FunctionalCommandBuilderImpl(ImmutableList.Builder<Predicate<CommandContext<?>>> predicates, @Nullable FunctionalTabHandler tabHandler, @Nullable String permission, @Nullable String permissionMessage, @Nullable String description, @Nullable String... aliases) {
         this.predicates = predicates;
         this.tabHandler = tabHandler;
         this.permission = permission;
         this.permissionMessage = permissionMessage;
         this.description = description;
+        this.aliases = aliases;
     }
 
     FunctionalCommandBuilderImpl() {
-        this(ImmutableList.builder(), null, null, null, null);
+        this(ImmutableList.builder(), null, null, null, null, null);
+    }
+
+    @Override
+    public FunctionalCommandBuilder<T> aliases(String... aliases) {
+        Objects.requireNonNull(aliases, "aliases");
+        this.aliases = aliases;
+        return this;
     }
 
     public FunctionalCommandBuilder<T> description(String description) {
@@ -117,7 +126,7 @@ class FunctionalCommandBuilderImpl<T extends CommandSender> implements Functiona
             return false;
         });
         // cast the generic type
-        return new FunctionalCommandBuilderImpl<>(this.predicates, this.tabHandler, this.permission, this.permissionMessage, this.description);
+        return new FunctionalCommandBuilderImpl<>(this.predicates, this.tabHandler, this.permission, this.permissionMessage, this.description, this.aliases);
     }
 
     @Override
@@ -132,7 +141,7 @@ class FunctionalCommandBuilderImpl<T extends CommandSender> implements Functiona
             return false;
         });
         // cast the generic type
-        return new FunctionalCommandBuilderImpl<>(this.predicates, this.tabHandler, this.permission, this.permissionMessage, this.description);
+        return new FunctionalCommandBuilderImpl<>(this.predicates, this.tabHandler, this.permission, this.permissionMessage, this.description, this.aliases);
     }
 
     @Override
@@ -205,6 +214,6 @@ class FunctionalCommandBuilderImpl<T extends CommandSender> implements Functiona
     @Override
     public Command handler(FunctionalCommandHandler handler) {
         Objects.requireNonNull(handler, "handler");
-        return new FunctionalCommand(this.predicates.build(), handler, tabHandler, permission, permissionMessage, description);
+        return new FunctionalCommand(this.predicates.build(), handler, tabHandler, permission, permissionMessage, description, aliases);
     }
 }


### PR DESCRIPTION
This is a quality of life addition that allows you to specify the aliases of the command within the command builder itself, thus removing the need to specify it on the register method.
Also adds a register method with no parameters that can be used when aliases are specified.