### PR TITLE
Implement isClosed in Abstract(Weak)CompositeTerminable

### DIFF
--- a/helper/src/main/java/me/lucko/helper/terminable/composite/AbstractCompositeTerminable.java
+++ b/helper/src/main/java/me/lucko/helper/terminable/composite/AbstractCompositeTerminable.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class AbstractCompositeTerminable implements CompositeTerminable {
     private final Deque<AutoCloseable> closeables = new ConcurrentLinkedDeque<>();
+    private boolean closed = false;
 
     protected AbstractCompositeTerminable() {
 
@@ -57,10 +58,16 @@ public class AbstractCompositeTerminable implements CompositeTerminable {
                 caught.add(e);
             }
         }
+        this.closed = true;
 
         if (!caught.isEmpty()) {
             throw new CompositeClosingException(caught);
         }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.closed;
     }
 
     @Override

--- a/helper/src/main/java/me/lucko/helper/terminable/composite/AbstractWeakCompositeTerminable.java
+++ b/helper/src/main/java/me/lucko/helper/terminable/composite/AbstractWeakCompositeTerminable.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class AbstractWeakCompositeTerminable implements CompositeTerminable {
     private final Deque<WeakReference<AutoCloseable>> closeables = new ConcurrentLinkedDeque<>();
+    private boolean closed = false;
 
     protected AbstractWeakCompositeTerminable() {
 
@@ -63,10 +64,16 @@ public class AbstractWeakCompositeTerminable implements CompositeTerminable {
                 caught.add(e);
             }
         }
+        this.closed = true;
 
         if (!caught.isEmpty()) {
             throw new CompositeClosingException(caught);
         }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return this.closed;
     }
 
     @Override


### PR DESCRIPTION
I'm unsure why exactly `isClosed()` was not implemented, but this PR implements it and makes it behave as expected when closing CompositeTerminables generated from CompositeTerminable.create()